### PR TITLE
JPA api endpoint 가 ID 필드를 보여주지 않음

### DIFF
--- a/src/main/java/com/example/springbootplayground/controller/MyController.java
+++ b/src/main/java/com/example/springbootplayground/controller/MyController.java
@@ -1,0 +1,22 @@
+package com.example.springbootplayground.controller;
+
+import com.example.springbootplayground.dto.MyDomainDto;
+import com.example.springbootplayground.repository.MyDomainRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class MyController {
+
+    private final MyDomainRepository myDomainRepository;
+
+    @GetMapping("/endpoint")
+    public List<MyDomainDto> endpoint() {
+        return myDomainRepository.findAll().stream().map(MyDomainDto::from).toList();
+    }
+
+}

--- a/src/main/java/com/example/springbootplayground/domain/MyDomain.java
+++ b/src/main/java/com/example/springbootplayground/domain/MyDomain.java
@@ -1,0 +1,29 @@
+package com.example.springbootplayground.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@Entity
+public class MyDomain {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter private String name;
+    @Setter private Integer age;
+
+    protected MyDomain() {}
+
+    public MyDomain(String name, Integer age) {
+        this.name = name;
+        this.age = age;
+    }
+
+}

--- a/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
+++ b/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
@@ -3,9 +3,11 @@ package com.example.springbootplayground.dto;
 import com.example.springbootplayground.domain.MyDomain;
 import lombok.Value;
 
+import javax.persistence.Id;
+
 @Value(staticConstructor = "of")
 public class MyDomainDto {
-    Long id;
+    @Id Long id;
     String name;
     Integer age;
 

--- a/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
+++ b/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
@@ -11,7 +11,10 @@ import javax.persistence.Id;
 @Entity
 @Data
 public class MyDomainDto {
-    private @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
     private String name;
     private Integer age;
 

--- a/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
+++ b/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
@@ -1,0 +1,19 @@
+package com.example.springbootplayground.dto;
+
+import com.example.springbootplayground.domain.MyDomain;
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class MyDomainDto {
+    Long id;
+    String name;
+    Integer age;
+
+    public static MyDomainDto from(MyDomain entity) {
+        return new MyDomainDto(
+                entity.getId(),
+                entity.getName(),
+                entity.getAge()
+        );
+    }
+}

--- a/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
+++ b/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
@@ -1,17 +1,18 @@
 package com.example.springbootplayground.dto;
 
 import com.example.springbootplayground.domain.MyDomain;
+import lombok.Data;
 import lombok.Value;
 
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-@Value(staticConstructor = "of")
+@Data(staticConstructor = "of")
 public class MyDomainDto {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
-    String name;
-    Integer age;
+    private final @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
+    private final String name;
+    private final Integer age;
 
     public static MyDomainDto from(MyDomain entity) {
         return new MyDomainDto(

--- a/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
+++ b/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
@@ -2,17 +2,30 @@ package com.example.springbootplayground.dto;
 
 import com.example.springbootplayground.domain.MyDomain;
 import lombok.Data;
-import lombok.Value;
 
+import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
-@Data(staticConstructor = "of")
+@Entity
+@Data
 public class MyDomainDto {
-    private final @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
-    private final String name;
-    private final Integer age;
+    private @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
+    private String name;
+    private Integer age;
+
+    protected MyDomainDto() {}
+
+    public MyDomainDto(Long id, String name, Integer age) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+
+    public static MyDomainDto of(Long id, String name, Integer age) {
+        return new MyDomainDto(id, name, age);
+    }
 
     public static MyDomainDto from(MyDomain entity) {
         return new MyDomainDto(

--- a/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
+++ b/src/main/java/com/example/springbootplayground/dto/MyDomainDto.java
@@ -3,11 +3,13 @@ package com.example.springbootplayground.dto;
 import com.example.springbootplayground.domain.MyDomain;
 import lombok.Value;
 
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Value(staticConstructor = "of")
 public class MyDomainDto {
-    @Id Long id;
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
     String name;
     Integer age;
 

--- a/src/main/java/com/example/springbootplayground/repository/MyDomainRepository.java
+++ b/src/main/java/com/example/springbootplayground/repository/MyDomainRepository.java
@@ -1,0 +1,7 @@
+package com.example.springbootplayground.repository;
+
+import com.example.springbootplayground.domain.MyDomain;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MyDomainRepository extends JpaRepository<MyDomain, Long> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+insert into my_domain (id, name, age) values
+(1, 'Uno', 20),
+(2, 'Jack', 30),
+(3, 'Ted', 40)
+;


### PR DESCRIPTION
특정 상황에서 컨트롤러 엔드포인트가 DTO 응답의 `id` 필드를 보여주지 않는다는 질문.
그러나 ebc19bd 까지는 재현되지 않는다.

This resolves #1 if merged.